### PR TITLE
Convert llvm_asm usage to asm macro

### DIFF
--- a/luma_core/src/integer.rs
+++ b/luma_core/src/integer.rs
@@ -10,7 +10,10 @@ pub fn cntlzw(value: u32) -> u32 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("cntlzw $0, $1" : "=r"(register) : "r"(value) :: "volatile");
+        asm!("cntlzw {0}, {1}",
+            lateout(reg) register,
+            in(reg) value,
+            options(nostack));
     }
 
     // Return the register value.

--- a/luma_core/src/io.rs
+++ b/luma_core/src/io.rs
@@ -10,10 +10,10 @@ pub fn read32(address: u32) -> u32 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("lwz $0,0($1) ; sync" 
-            : "=r"(register) 
-            : "b"(0xc000_0000 | address)
-            :: "volatile");
+        asm!("lwz {0},0({1}) ; sync",
+            lateout(reg) register, 
+            in(reg) (0xc000_0000 | address),
+            options(nostack));
     }
 
     // Return the register value.
@@ -25,8 +25,9 @@ pub fn read32(address: u32) -> u32 {
 pub fn write32(address: u32, value: u32) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("stw $0,0($1) ; eieio" 
-            :: "r"(value), "b"(0xc000_0000 | address));
+        asm!("stw {0},0({1}) ; eieio", 
+            in(reg) value, in(reg) (0xc000_0000 | address), 
+            options(nostack));
     }
 }
 
@@ -38,10 +39,10 @@ pub fn read16(address: u32) -> u16 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("lhz $0,0($1) ; sync" 
-            : "=r"(register) 
-            : "b"(0xc000_0000 | address)
-            :: "volatile");
+        asm!("lhz {0},0({1}) ; sync", 
+            lateout(reg) register,
+            in(reg) (0xc000_0000 | address), 
+            options(nostack));
     }
 
     // Return the register value.
@@ -53,8 +54,9 @@ pub fn read16(address: u32) -> u16 {
 pub fn write16(address: u32, value: u16) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("sth $0,0($1) ; eieio" 
-            :: "r"(value), "b"(0xc000_0000 | address));
+        asm!("sth {0},0({1}) ; eieio",
+            in(reg) value, in(reg) (0xc000_0000 | address), 
+            options(nostack));
     }
 }
 
@@ -66,10 +68,10 @@ pub fn read8(address: u32) -> u8 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("lbz $0,0($1) ; sync" 
-            : "=r"(register) 
-            : "b"(0xc000_0000 | address)
-            :: "volatile");
+        asm!("lbz {0},0({1}) ; sync",
+            lateout(reg) register,
+            in(reg) (0xc000_0000 | address),
+            options(nostack));
     }
 
     // Return the register value.
@@ -81,8 +83,9 @@ pub fn read8(address: u32) -> u8 {
 pub fn write8(address: u32, value: u8) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("stb $0,0($1) ; eieio" 
-            :: "r"(value), "b"(0xc000_0000 | address));
+        asm!("stb {0},0({1}) ; eieio",
+            in(reg) value, in(reg) (0xc000_0000 | address),
+            options(nostack));
     }
 }
 
@@ -91,7 +94,8 @@ pub fn write8(address: u32, value: u8) {
 pub fn writef32(address: u32, value: f32) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("stfs $0,0($1) ; eieio" 
-            :: "f"(value), "b"(0xc000_0000 | address));
+        asm!("stfs {0},0({1}) ; eieio",
+            in(freg) value, in(reg) (0xc000_0000 | address),
+            options(nostack));
     }
 }

--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -5,7 +5,7 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(unused_attributes)]
-#![feature(llvm_asm, global_asm)]
+#![feature(global_asm, asm)]
 
 // Broadway Processor Utilities
 pub mod processor;

--- a/luma_core/src/loadstore.rs
+++ b/luma_core/src/loadstore.rs
@@ -10,10 +10,10 @@ pub fn lhbrx(base: u32, index: u32) -> u16 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("lhbrx $0, $1, $2" 
-            : "=r"(register)
-            : "b%"(index), "r"(base) 
-            : "memory" : "volatile");
+        asm!("lhbrx {0}, {1}, {2}",
+            lateout(reg) register,
+            in(reg_nonzero) index, in(reg) base, 
+            options(nostack));
     }
 
     // Return the register value.
@@ -28,10 +28,10 @@ pub fn lwbrx(base: u32, index: u32) -> u32 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("lwbrx $0, $1, $2" 
-            : "=r"(register)
-            : "b%"(index), "r"(base) 
-            : "memory" : "volatile");
+        asm!("lwbrx {0}, {1}, {2}",
+            lateout(reg) register,
+            in(reg_nonzero) index, in(reg) base,
+            options(nostack));
     }
 
     // Return the register value.
@@ -43,9 +43,9 @@ pub fn lwbrx(base: u32, index: u32) -> u32 {
 pub fn sthbrx(base: u32, index: u32, value: u32) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("sthbrx $0, $1, $2" :
-            : "r"(value), "b%"(index), "r"(base) 
-            : "memory" : "volatile");
+        asm!("sthbrx {0}, {1}, {2}",
+            in(reg) value, in(reg_nonzero) index, in(reg) base, 
+            options(nostack));
     }
 }
 
@@ -54,8 +54,8 @@ pub fn sthbrx(base: u32, index: u32, value: u32) {
 pub fn stwbrx(base: u32, index: u32, value: u32) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("stwbrx $0, $1, $2" :
-            : "r"(value), "b%"(index), "r"(base) 
-            : "memory" : "volatile");
+        asm!("stwbrx {0}, {1}, {2}",
+            in(reg) value, in(reg_nonzero) index, in(reg) base, 
+            options(nostack));
     }
 }

--- a/luma_core/src/register.rs
+++ b/luma_core/src/register.rs
@@ -8,8 +8,8 @@ macro_rules! mfspr {
     ($R:tt) => {
         unsafe {
             let mut output: u32;
-            llvm_asm!( concat!("mfspr", " $0,", stringify!($R))
-                : "=r"(output) ::: "volatile"
+            asm!( concat!("mfspr", " {0},", stringify!($R)),
+                out(reg) output, options(nostack)
             );
             output
         }
@@ -21,8 +21,8 @@ macro_rules! mfspr {
 macro_rules! mtspr {
     ($val:expr, $R:tt) => {
         unsafe {
-            llvm_asm!( concat!("mtspr", ' ', stringify!($R), ",$0")
-                :: "r"($val) :: "volatile"
+            asm!( concat!("mtspr", ' ', stringify!($R), ",{0}"),
+                in(reg) $val, options(nostack)
             )
         }
     }
@@ -36,7 +36,9 @@ pub fn mfpvr() -> u32 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("mfpvr $0" : "=r"(register) ::: "volatile");
+        asm!("mfpvr {0}",
+            out(reg) register,
+            options(nostack));
     }
 
     // Return the register value.
@@ -51,7 +53,9 @@ pub fn mfmsr() -> u32 {
 
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("mfmsr $0" : "=r"(register) ::: "volatile");
+        asm!("mfmsr {0}",
+            out(reg) register,
+            options(nostack));
     }
 
     // Return the register value.
@@ -63,7 +67,9 @@ pub fn mfmsr() -> u32 {
 pub fn mtmsr(value: u32) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("mtmsr $0" :: "r"(value) :: "volatile");
+        asm!("mtmsr {0}",
+            in(reg) value,
+            options(nostack));
     }
 }
 
@@ -72,6 +78,8 @@ pub fn mtmsr(value: u32) {
 pub fn mtdec(value: u32) {
     // Run the assembly instruction.
     unsafe {
-        llvm_asm!("mtdec $0" :: "r"(value) :: "volatile");
+        asm!("mtdec {0}",
+            in(reg) value,
+            options(nostack));
     }
 }


### PR DESCRIPTION
This PR converts ``llvm_asm`` usage to the new ``asm`` macro. 

When converting to the new macro, the assembly output for each version was compared to maintain the same representation, but there still could be issues that need to be tested.