### PR TITLE
Add .elf suffix to build targets

### DIFF
--- a/powerpc-unknown-eabi.json
+++ b/powerpc-unknown-eabi.json
@@ -2,6 +2,7 @@
     "arch": "powerpc",
     "cpu": "750",
     "env": "newlib",
+    "exe-suffix": ".elf",
     "data-layout": "E-m:e-p:32:32-i64:64-n32",
     "executables": true,
     "has-elf-tls": false,


### PR DESCRIPTION
Dolphin requires this extension in order to detect them as ELF files and to boot them.