### PR TITLE
Increase the heap size to 24 MiB − stack size

### DIFF
--- a/luma_runtime/src/lib.rs
+++ b/luma_runtime/src/lib.rs
@@ -43,7 +43,9 @@ where
 
     // Setup the allocator before the user_main is called.
     unsafe {
-        ALLOCATOR.lock().init(stack_addr, out_size);
+        ALLOCATOR
+            .lock()
+            .init(stack_addr, 24 * 1024 * 1024 - out_size);
     }
 
     // Jump to user defined main function.


### PR DESCRIPTION
The current code was setting it to the same size as the stack, that is
128 KiB, which is clearly not enough to work with.  In a future commit,
I have to allocate 600 KiB to use as the XFB, and this limit was way too
low.

I chose 24 MiB because that’s the size of MEM1, that way we don’t have
to handle MEM2 and the gap it includes, and we can also be compatible
with the GameCube (once we stop using HID4 and other such registers).