### PR TITLE
Make asm!() work again in nightly

### DIFF
--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -5,7 +5,13 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(unused_attributes)]
-#![feature(global_asm, asm, box_into_boxed_slice, allocator_api)]
+#![feature(
+    global_asm,
+    asm,
+    asm_experimental_arch,
+    box_into_boxed_slice,
+    allocator_api
+)]
 
 extern crate alloc;
 

--- a/luma_runtime/src/lib.rs
+++ b/luma_runtime/src/lib.rs
@@ -5,7 +5,13 @@
 //!
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
-#![feature(global_asm, lang_items, llvm_asm, alloc_error_handler)]
+#![feature(
+    global_asm,
+    asm_experimental_arch,
+    lang_items,
+    llvm_asm,
+    alloc_error_handler
+)]
 
 use core::{alloc::Layout, panic::PanicInfo};
 use linked_list_allocator::LockedHeap;

--- a/src/bin/vi-draw.rs
+++ b/src/bin/vi-draw.rs
@@ -3,7 +3,6 @@
 //! The drawing has been ported from Weston’s clients/simple-shm.c
 
 #![no_std]
-#![feature(asm)]
 
 extern crate luma_core;
 extern crate luma_runtime;


### PR DESCRIPTION
On the 9th of November, the nightly compiler split PowerPC `asm!()` support into the new `asm_experimental_arch` feature flag, see https://github.com/rust-lang/rust/issues/72016