### PR TITLE
Import asm!() and global_asm!() for latest nightly

### DIFF
--- a/luma_core/src/cache.rs
+++ b/luma_core/src/cache.rs
@@ -3,6 +3,7 @@
 //! Contains functions for the L1, L2, Data and Instruction caches.
 
 use crate::{mfspr, mtspr, processor};
+use core::arch::{asm, global_asm};
 
 global_asm!(include_str!("../asm/cache.S"));
 

--- a/luma_core/src/integer.rs
+++ b/luma_core/src/integer.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains functions for integer instructions.
 
+use core::arch::asm;
+
 /// (`cntlzw`) PowerPC Integer Instruction
 #[inline(always)]
 pub fn cntlzw(value: u32) -> u32 {

--- a/luma_core/src/io.rs
+++ b/luma_core/src/io.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains functions for basic I/O.
 
+use core::arch::asm;
+
 /// Read a 32-bit value from an address.
 #[inline(always)]
 pub fn read32(address: u32) -> u32 {

--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -5,13 +5,7 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(unused_attributes)]
-#![feature(
-    global_asm,
-    asm,
-    asm_experimental_arch,
-    box_into_boxed_slice,
-    allocator_api
-)]
+#![feature(asm_experimental_arch, box_into_boxed_slice, allocator_api)]
 
 extern crate alloc;
 

--- a/luma_core/src/loadstore.rs
+++ b/luma_core/src/loadstore.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains functions for load and store instructions.
 
+use core::arch::asm;
+
 /// (`lhbrx`) PowerPC Load Instruction
 #[inline(always)]
 pub fn lhbrx(base: u32, index: u32) -> u16 {

--- a/luma_core/src/processor.rs
+++ b/luma_core/src/processor.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains functions for system instructions.
 
+use core::arch::asm;
+
 /// PowerPC NOP Instruction
 #[inline(always)]
 pub fn ppc_nop() {

--- a/luma_core/src/register.rs
+++ b/luma_core/src/register.rs
@@ -2,6 +2,8 @@
 //!
 //! Contains functions for register instructions.
 
+use core::arch::asm;
+
 /// (`mfspr`) PowerPC Register Instruction
 #[macro_export]
 macro_rules! mfspr {

--- a/luma_runtime/src/lib.rs
+++ b/luma_runtime/src/lib.rs
@@ -13,6 +13,7 @@
     alloc_error_handler
 )]
 
+use core::arch::global_asm;
 use core::{alloc::Layout, panic::PanicInfo};
 use linked_list_allocator::LockedHeap;
 #[allow(unused_imports)]

--- a/luma_runtime/src/lib.rs
+++ b/luma_runtime/src/lib.rs
@@ -5,13 +5,7 @@
 //!
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
-#![feature(
-    global_asm,
-    asm_experimental_arch,
-    lang_items,
-    llvm_asm,
-    alloc_error_handler
-)]
+#![feature(asm_experimental_arch, lang_items, alloc_error_handler)]
 
 use core::arch::global_asm;
 use core::{alloc::Layout, panic::PanicInfo};


### PR DESCRIPTION
Since the 19th of December, these two macros are not exported from the prelude any longer, and must be imported from `core::arch` instead.

See https://github.com/rust-lang/rust/issues/87228