### PR TITLE
Make the vi-draw example faster

### DIFF
--- a/src/bin/vi-draw.rs
+++ b/src/bin/vi-draw.rs
@@ -62,11 +62,11 @@ fn paint_pixels(mut image: *mut u16, padding: u32, width: u32, height: u32, time
             let r2 = (x - halfw) * (x - halfw) + y2;
 
             if r2 < ir {
-                v = (r2 / 32 + time / 64) * 0x0080401;
+                v = (r2 / 32 + time / 4) * 0x0080401;
             } else if r2 < or {
-                v = (y + time / 32) * 0x0080401;
+                v = (y + time / 2) * 0x0080401;
             } else {
-                v = (x + time / 16) * 0x0080401;
+                v = (x + time) * 0x0080401;
             }
             v &= 0x00ffffff;
 
@@ -89,7 +89,7 @@ fn main() {
         unsafe { xfb.offset(i).write(0xff80) };
     }
 
-    // Then draw to it as fast as we can (that is, super slowly).
+    // Then draw to it as fast as we can.
     let mut i = 0;
     loop {
         paint_pixels(xfb, 20, 640, 480, i);


### PR DESCRIPTION
The original code from Weston gave wall-time milliseconds as the time base to the draw function, while this port used the frame number instead, making us draw a different frame only once every 16 draw calls.

There is still no vsync, we still draw as fast as we can, but at least now the demo is at least much more visually pleasing!

Edit: this PR depends on #10.