### PR TITLE
Add println!() support, working in Dolphin

### DIFF
--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -7,6 +7,8 @@
 #![allow(unused_attributes)]
 #![feature(asm_experimental_arch, box_into_boxed_slice, allocator_api)]
 
+use core::arch::asm;
+
 extern crate alloc;
 
 // Broadway Processor Utilities
@@ -32,3 +34,19 @@ pub mod allocate;
 
 // VI Subsystem
 pub mod vi;
+
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn puts(unused: u32, message: *const u8) {
+    // Do nothing, this is for Dolphin’s use until we get actual USB Gecko support.
+    asm!("/* {0} {1} */", in(reg) unused, in(reg) message);
+}
+
+#[macro_export]
+macro_rules! println {
+    ($fmt: expr, $($args: expr),*) => {{
+        // TODO: figure out a way to not have to import those crates with these names in user code.
+        let string = alloc::format!($fmt, $($args),*);
+        unsafe { luma_core::puts(0, string.as_ptr()) };
+    }}
+}

--- a/luma_runtime/src/lib.rs
+++ b/luma_runtime/src/lib.rs
@@ -7,11 +7,14 @@
 #![no_std]
 #![feature(asm_experimental_arch, lang_items, alloc_error_handler)]
 
+extern crate alloc;
+
 use core::arch::global_asm;
 use core::{alloc::Layout, panic::PanicInfo};
 use linked_list_allocator::LockedHeap;
 #[allow(unused_imports)]
 use luma_core::cache::*;
+use luma_core::println;
 
 // Import linker symbols for allocator initialization.
 extern "C" {
@@ -66,7 +69,8 @@ impl Termination for () {}
 /// This function is called on panic.
 #[cfg_attr(not(test), panic_handler)]
 #[no_mangle]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    println!("{}", info);
     loop {}
 }
 


### PR DESCRIPTION
Once #9 gets fixed to work with a real USB Gecko, this will have to do as a way to communicate with the outside world for debugging purposes.

I quite dislike how the `alloc` and `luma_core` crates must be imported under these names in order for my macro to work, but I couldn’t figure out a better way which still compiles.

It also displays `panic!()` info using this new printing facility.