### PR TITLE
Remove obsolete cargo options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["strip"]
-
 [package]
 name = "luma"
 version = "0.1.0"

--- a/powerpc-unknown-eabi.json
+++ b/powerpc-unknown-eabi.json
@@ -5,7 +5,6 @@
     "exe-suffix": ".elf",
     "data-layout": "E-m:e-p:32:32-i64:64-n32",
     "executables": true,
-    "has-elf-tls": false,
     "has-rpath": true,
     "llvm-target": "powerpc-unknown-eabi",
     "linker": "rust-lld",


### PR DESCRIPTION
These would emit warnings every time we build any of the crates we depend on.