### PR TITLE
Replace __crt0stack with __stack_addr in crt0

### DIFF
--- a/luma_runtime/asm/crt0.S
+++ b/luma_runtime/asm/crt0.S
@@ -47,9 +47,7 @@ _start:
 
 	.section .bss
 	.balign 8
-__crt0stack_end:
 	.space 0x4000
-__crt0stack:
 
 	.globl __system_argv
 	.section	.sdata,"aw",@progbits

--- a/luma_runtime/asm/runtime.S
+++ b/luma_runtime/asm/runtime.S
@@ -2,7 +2,7 @@
 //	   Runtime Assembly	    //
 // ======================== //
 
-.extern __crt0stack
+.extern __stack_addr
 .extern InitCache,InitPS,InitFPRS
 
 // --------------------------------------------------------------- //
@@ -54,8 +54,8 @@ ClearGPRS:
 	li      30,0
 	li      31,0
 
-	lis		1,__crt0stack@h		    // we take 0x8173FFF0 as the topmost starting point for our stack,this gives us ~128Kb Stack
-	ori		1,1,__crt0stack@l
+	lis		1,__stack_addr@h	// Use a 128 KiB stack, defined in linker.ld.
+	ori		1,1,__stack_addr@l
 	addi	1,1,-4
 	stw		0,0(1)
 	stwu	1,-56(1)


### PR DESCRIPTION
Unlike what the comment said, `__crt0stack` was placed at the end of the `.bss` section.  In release mode (since approximately February), this made `memset(.bss)` wipe the current stack, thus make it return back to `NULL` instead of to `_start`.

Fixes #14.