### PR TITLE
Stop stripping debug symbols in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [profile]
 dev = { panic = "abort" }
-release = { panic = "abort", lto = true, codegen-units = 1, strip = "symbols", opt-level = "s" }
+release = { panic = "abort", lto = true, codegen-units = 1, opt-level = "s" }
 
 [dependencies]
 luma_core = { path = "luma_core" }


### PR DESCRIPTION
During development, it is quite helpful to keep symbol names for debugging in Dolphin.

It almost doubles the size of the final ELF, our sole example grows from 73 KiB to 136 KiB, but we can go back to stripping symbols in a future where luma is already usable and needs only minor debugging.