### PR TITLE
Add an iterator over XFB rows

### DIFF
--- a/luma_core/src/allocate.rs
+++ b/luma_core/src/allocate.rs
@@ -1,16 +1,20 @@
 use alloc::alloc::{alloc, Layout};
 use alloc::boxed::Box;
 use core::pin::Pin;
+use core::slice;
 
 const CACHELINE: usize = 32;
 
 /// Allocate a slice aligned to a cacheline, and return it pinned.
-pub fn alloc_aligned(size: usize) -> Pin<Box<[u8]>> {
-    let layout = Layout::from_size_align(size, CACHELINE).unwrap();
-    let ptr = unsafe { alloc(layout) };
-    let boxed = unsafe { Box::from_raw(ptr) };
-    let slice = Box::into_boxed_slice(boxed);
-    Pin::from(slice)
+pub fn alloc_aligned<T: Copy>(size: usize) -> Pin<Box<[T]>> {
+    let layout = Layout::array::<T>(size)
+        .unwrap()
+        .align_to(CACHELINE)
+        .unwrap();
+    let ptr = unsafe { alloc(layout) } as *mut T;
+    let slice = unsafe { slice::from_raw_parts(ptr, size) };
+    let boxed = Box::from(slice);
+    Pin::from(boxed)
 }
 
 /// Allocate an array aligned to a cacheline, and return it pinned.

--- a/luma_core/src/ipc.rs
+++ b/luma_core/src/ipc.rs
@@ -1,7 +1,7 @@
-use core::ptr::from_exposed_addr_mut;
+use core::ptr;
 
 //bits 0..=31 = physical address of ipc request
-const HW_IPC_PPCMSG: usize = 0xCD00_0000usize; //from_exposed_addr_mut(0xCD00_0000);
+const HW_IPC_PPCMSG: *mut u32 = ptr::without_provenance_mut(0xCD00_0000);
 
 //bit 0 = X1 | Execute IPC request
 //bit 1 = Y2 | Acknowledge IPC request
@@ -9,10 +9,10 @@ const HW_IPC_PPCMSG: usize = 0xCD00_0000usize; //from_exposed_addr_mut(0xCD00_00
 //bit 3 = X2 | Relaunch IPC
 //bit 4 = IY1 | IPC request reply send out IPC interrupt
 //bit 5 = IY2 | IPC request acknowledge sends out IPC interrupt
-const HW_IPC_PPCCTRL: usize = 0xCD00_0004usize; //from_exposed_addr_mut(0xCD00_0004);
+const HW_IPC_PPCCTRL: *mut u32 = ptr::without_provenance_mut(0xCD00_0004);
 
 //bits 0..=31 = physical address of ipc request
-const HW_IPC_ARMMSG: usize = 0xCD00_0008usize; //from_exposed_addr_mut(0xCD00_0008);
+const HW_IPC_ARMMSG: *mut u32 = ptr::without_provenance_mut(0xCD00_0008);
 
 //bit 0 = Y1 | IPC request reply available
 //bit 1 = X2 | Relauch IPC
@@ -20,7 +20,7 @@ const HW_IPC_ARMMSG: usize = 0xCD00_0008usize; //from_exposed_addr_mut(0xCD00_00
 //bit 3 = Y2 | Acknowledge IPC request
 //bit 4 = IX1 | Execute ipc request send IPC interrupt
 //bit 5 = IX2 | Relaunch IPC sends IPC interrupt
-const HW_IPC_ARMCTRL: usize = 0xCD00_000Cusize; //from_exposed_addr_mut(0xCD00_000C);
+const HW_IPC_ARMCTRL: *mut u32 = ptr::without_provenance_mut(0xCD00_000C);
 
 /// IPC Message Address (for BOTH ARM AND PPC)
 #[repr(transparent)]
@@ -32,23 +32,19 @@ impl IpcMessageAddress {
     }
 
     pub fn read_ppc() -> Self {
-        let hw_ipc_ppcmsg = from_exposed_addr_mut::<u32>(HW_IPC_PPCMSG);
-        Self(unsafe { hw_ipc_ppcmsg.read_volatile() })
+        Self(unsafe { HW_IPC_PPCMSG.read_volatile() })
     }
 
     pub fn write_ppc(self) {
-        let hw_ipc_ppcmsg = from_exposed_addr_mut::<u32>(HW_IPC_PPCMSG);
-        unsafe { hw_ipc_ppcmsg.write_volatile(self.0) }
+        unsafe { HW_IPC_PPCMSG.write_volatile(self.0) }
     }
 
     pub fn read_arm() -> Self {
-        let hw_ipc_armmsg = from_exposed_addr_mut::<u32>(HW_IPC_ARMMSG);
-        Self(unsafe { hw_ipc_armmsg.read_volatile() })
+        Self(unsafe { HW_IPC_ARMMSG.read_volatile() })
     }
 
     pub fn write_arm(self) {
-        let hw_ipc_armmsg = from_exposed_addr_mut::<u32>(HW_IPC_ARMMSG);
-        unsafe { hw_ipc_armmsg.write_volatile(self.0) }
+        unsafe { HW_IPC_ARMMSG.write_volatile(self.0) }
     }
 
     pub fn address(&self) -> u32 {
@@ -79,13 +75,11 @@ impl PpcIpcControl {
     }
 
     pub fn read() -> Self {
-        let hw_ipc_ppcctrl = from_exposed_addr_mut::<u32>(HW_IPC_PPCCTRL);
-        Self(unsafe { hw_ipc_ppcctrl.read_volatile() })
+        Self(unsafe { HW_IPC_PPCCTRL.read_volatile() })
     }
 
     pub fn write(self) {
-        let hw_ipc_ppcctrl = from_exposed_addr_mut::<u32>(HW_IPC_PPCCTRL);
-        unsafe { hw_ipc_ppcctrl.write_volatile(self.0) }
+        unsafe { HW_IPC_PPCCTRL.write_volatile(self.0) }
     }
 
     pub fn execute(&self) -> bool {
@@ -153,13 +147,11 @@ impl ArmIpcControl {
     }
 
     pub fn read() -> Self {
-        let hw_ipc_armctrl = from_exposed_addr_mut::<u32>(HW_IPC_ARMCTRL);
-        Self(unsafe { hw_ipc_armctrl.read_volatile() })
+        Self(unsafe { HW_IPC_ARMCTRL.read_volatile() })
     }
 
     pub fn write(self) {
-        let hw_ipc_armctrl = from_exposed_addr_mut::<u32>(HW_IPC_ARMCTRL);
-        unsafe { hw_ipc_armctrl.write_volatile(self.0) }
+        unsafe { HW_IPC_ARMCTRL.write_volatile(self.0) }
     }
 
     pub fn execute(&self) -> bool {

--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -5,13 +5,7 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(unused_attributes)]
-#![feature(
-    asm_experimental_arch,
-    box_into_boxed_slice,
-    allocator_api,
-    exposed_provenance,
-    strict_provenance
-)]
+#![feature(asm_experimental_arch, box_into_boxed_slice, allocator_api)]
 
 extern crate alloc;
 


### PR DESCRIPTION
This emits slices of `u16`, and allows users to not use unsafe for drawing.

This is based on #21, since it wouldn’t build on current nightly otherwise.