### PR TITLE
Update things so that Luma builds again on recent nightly

### DIFF
--- a/luma_core/src/ipc.rs
+++ b/luma_core/src/ipc.rs
@@ -1,7 +1,5 @@
-use core::ptr::from_exposed_addr_mut;
-
 //bits 0..=31 = physical address of ipc request
-const HW_IPC_PPCMSG: usize = 0xCD00_0000usize; //from_exposed_addr_mut(0xCD00_0000);
+const HW_IPC_PPCMSG: *mut u32 = 0xCD00_0000 as *mut u32;
 
 //bit 0 = X1 | Execute IPC request
 //bit 1 = Y2 | Acknowledge IPC request
@@ -9,10 +7,10 @@ const HW_IPC_PPCMSG: usize = 0xCD00_0000usize; //from_exposed_addr_mut(0xCD00_00
 //bit 3 = X2 | Relaunch IPC
 //bit 4 = IY1 | IPC request reply send out IPC interrupt
 //bit 5 = IY2 | IPC request acknowledge sends out IPC interrupt
-const HW_IPC_PPCCTRL: usize = 0xCD00_0004usize; //from_exposed_addr_mut(0xCD00_0004);
+const HW_IPC_PPCCTRL: *mut u32 = 0xCD00_0004 as *mut u32;
 
 //bits 0..=31 = physical address of ipc request
-const HW_IPC_ARMMSG: usize = 0xCD00_0008usize; //from_exposed_addr_mut(0xCD00_0008);
+const HW_IPC_ARMMSG: *mut u32 = 0xCD00_0008 as *mut u32;
 
 //bit 0 = Y1 | IPC request reply available
 //bit 1 = X2 | Relauch IPC
@@ -20,7 +18,7 @@ const HW_IPC_ARMMSG: usize = 0xCD00_0008usize; //from_exposed_addr_mut(0xCD00_00
 //bit 3 = Y2 | Acknowledge IPC request
 //bit 4 = IX1 | Execute ipc request send IPC interrupt
 //bit 5 = IX2 | Relaunch IPC sends IPC interrupt
-const HW_IPC_ARMCTRL: usize = 0xCD00_000Cusize; //from_exposed_addr_mut(0xCD00_000C);
+const HW_IPC_ARMCTRL: *mut u32 = 0xCD00_000C as *mut u32;
 
 /// IPC Message Address (for BOTH ARM AND PPC)
 #[repr(transparent)]
@@ -32,23 +30,19 @@ impl IpcMessageAddress {
     }
 
     pub fn read_ppc() -> Self {
-        let hw_ipc_ppcmsg = from_exposed_addr_mut::<u32>(HW_IPC_PPCMSG);
-        Self(unsafe { hw_ipc_ppcmsg.read_volatile() })
+        Self(unsafe { HW_IPC_PPCMSG.read_volatile() })
     }
 
     pub fn write_ppc(self) {
-        let hw_ipc_ppcmsg = from_exposed_addr_mut::<u32>(HW_IPC_PPCMSG);
-        unsafe { hw_ipc_ppcmsg.write_volatile(self.0) }
+        unsafe { HW_IPC_PPCMSG.write_volatile(self.0) }
     }
 
     pub fn read_arm() -> Self {
-        let hw_ipc_armmsg = from_exposed_addr_mut::<u32>(HW_IPC_ARMMSG);
-        Self(unsafe { hw_ipc_armmsg.read_volatile() })
+        Self(unsafe { HW_IPC_ARMMSG.read_volatile() })
     }
 
     pub fn write_arm(self) {
-        let hw_ipc_armmsg = from_exposed_addr_mut::<u32>(HW_IPC_ARMMSG);
-        unsafe { hw_ipc_armmsg.write_volatile(self.0) }
+        unsafe { HW_IPC_ARMMSG.write_volatile(self.0) }
     }
 
     pub fn address(&self) -> u32 {
@@ -79,13 +73,11 @@ impl PpcIpcControl {
     }
 
     pub fn read() -> Self {
-        let hw_ipc_ppcctrl = from_exposed_addr_mut::<u32>(HW_IPC_PPCCTRL);
-        Self(unsafe { hw_ipc_ppcctrl.read_volatile() })
+        Self(unsafe { HW_IPC_PPCCTRL.read_volatile() })
     }
 
     pub fn write(self) {
-        let hw_ipc_ppcctrl = from_exposed_addr_mut::<u32>(HW_IPC_PPCCTRL);
-        unsafe { hw_ipc_ppcctrl.write_volatile(self.0) }
+        unsafe { HW_IPC_PPCCTRL.write_volatile(self.0) }
     }
 
     pub fn execute(&self) -> bool {
@@ -153,13 +145,11 @@ impl ArmIpcControl {
     }
 
     pub fn read() -> Self {
-        let hw_ipc_armctrl = from_exposed_addr_mut::<u32>(HW_IPC_ARMCTRL);
-        Self(unsafe { hw_ipc_armctrl.read_volatile() })
+        Self(unsafe { HW_IPC_ARMCTRL.read_volatile() })
     }
 
     pub fn write(self) {
-        let hw_ipc_armctrl = from_exposed_addr_mut::<u32>(HW_IPC_ARMCTRL);
-        unsafe { hw_ipc_armctrl.write_volatile(self.0) }
+        unsafe { HW_IPC_ARMCTRL.write_volatile(self.0) }
     }
 
     pub fn execute(&self) -> bool {

--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -5,13 +5,7 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(unused_attributes)]
-#![feature(
-    asm_experimental_arch,
-    box_into_boxed_slice,
-    allocator_api,
-    exposed_provenance,
-    strict_provenance
-)]
+#![feature(asm_experimental_arch, box_into_boxed_slice, allocator_api)]
 
 extern crate alloc;
 

--- a/powerpc-unknown-eabi.json
+++ b/powerpc-unknown-eabi.json
@@ -3,7 +3,7 @@
     "cpu": "750",
     "env": "newlib",
     "exe-suffix": ".elf",
-    "data-layout": "E-m:e-p:32:32-i64:64-n32",
+    "data-layout": "E-m:e-p:32:32-Fn32-i64:64-n32",
     "executables": true,
     "has-rpath": true,
     "llvm-target": "powerpc-unknown-eabi",


### PR DESCRIPTION
The first commit is for a simple LLVM change, the data layout is more descriptive now.

The second one is about an issue we’ve had since basically forever, but which is becoming worse with provenance support being added to the language.  Basically, it’s always been UB to cast a random integer into a pointer, but that works on von Neumann machines like ours.  The `exposed_provenance` and `strict_provenance` features [have been stabilized](https://github.com/rust-lang/rust/pull/130350), so let’s migrate to their functions at least, even though it’s still UB to use them in our case, see the commit message for why.  https://github.com/rust-lang/rust/issues/98593 might end up giving us a function we can use for that usecase, but until then let’s keep one UB which currently works.