### PR TITLE
Fix for all of the changes having happened on nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           toolchain: nightly
           command: build
+          args: -Z json-target-spec
 
   lints:
     name: Lints
@@ -49,3 +50,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -Z json-target-spec

--- a/luma_core/src/lib.rs
+++ b/luma_core/src/lib.rs
@@ -5,7 +5,6 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(unused_attributes)]
-#![feature(asm_experimental_arch, box_into_boxed_slice, allocator_api)]
 
 extern crate alloc;
 

--- a/luma_core/src/vi.rs
+++ b/luma_core/src/vi.rs
@@ -50,13 +50,13 @@ impl Xfb {
     }
 
     /// Get an immutable iterator over the rows of this XFB.
-    pub fn iter(&self) -> Chunks<u16> {
+    pub fn iter(&self) -> Chunks<'_, u16> {
         let stride = self.stride_in_u16();
         self.data.chunks(stride)
     }
 
     /// Get a mutable iterator over the rows of this XFB.
-    pub fn iter_mut(&mut self) -> ChunksMut<u16> {
+    pub fn iter_mut(&mut self) -> ChunksMut<'_, u16> {
         let stride = self.stride_in_u16();
         self.data.chunks_mut(stride)
     }

--- a/luma_runtime/src/lib.rs
+++ b/luma_runtime/src/lib.rs
@@ -6,7 +6,7 @@
 //! **NOTE**: This is currently in a very experimental state and is subject to change.
 #![no_std]
 #![allow(internal_features)]
-#![feature(asm_experimental_arch, lang_items)]
+#![feature(lang_items)]
 
 extern crate alloc;
 
@@ -69,7 +69,6 @@ impl Termination for () {}
 
 /// This function is called on panic.
 #[cfg_attr(not(test), panic_handler)]
-#[unsafe(no_mangle)]
 fn panic(info: &PanicInfo) -> ! {
     println!("{}", info);
     loop {}
@@ -77,5 +76,4 @@ fn panic(info: &PanicInfo) -> ! {
 
 /// Error handler personality language item (current no-op, to satisfy clippy).
 #[cfg_attr(not(test), lang = "eh_personality")]
-#[unsafe(no_mangle)]
 extern "C" fn rust_eh_personality() {}

--- a/powerpc-unknown-eabi.json
+++ b/powerpc-unknown-eabi.json
@@ -23,7 +23,7 @@
     "target-endian": "big",
     "target-family": "unix",
     "target-mcount": "_mcount",
-    "target-c-int-width": "32",
-    "target-pointer-width": "32",
+    "target-c-int-width": 32,
+    "target-pointer-width": 32,
     "vendor": "nintendo"
 }


### PR DESCRIPTION
Most of our experimental features have been stabilized since the last update, this is a very pleasant change!

The only remaining one is `feature(lang_items)`, and the `powerpc-unknown-eabi.json` having been unstabilized, but we should eventually request a proper triple from Rust itself instead of carrying it here.  In the meantime, it requires passing `-Z json-target-spec` to cargo.